### PR TITLE
ACL checks are not sufficient for checking access.  Access is falsely denied when bucket policy is used.

### DIFF
--- a/src/main/java/org/carlspring/cloud/storage/s3fs/S3AccessControlList.java
+++ b/src/main/java/org/carlspring/cloud/storage/s3fs/S3AccessControlList.java
@@ -58,10 +58,10 @@ public class S3AccessControlList
         {
             // Checking the ACL grants is not sufficient to determine access as bucket policy may override ACL.
             // Any permission problems will have to be handled at time of access.
-            switch (accessMode)
+            if (accessMode == AccessMode.EXECUTE)
             {
-                case EXECUTE:
-                    throw new AccessDeniedException(fileName(), null, "file is not executable");
+                throw new AccessDeniedException(fileName(), null, "file is not executable");
+            }
             }
         }
     }

--- a/src/main/java/org/carlspring/cloud/storage/s3fs/S3AccessControlList.java
+++ b/src/main/java/org/carlspring/cloud/storage/s3fs/S3AccessControlList.java
@@ -2,14 +2,6 @@ package org.carlspring.cloud.storage.s3fs;
 
 import java.nio.file.AccessDeniedException;
 import java.nio.file.AccessMode;
-import java.util.EnumSet;
-import java.util.stream.StreamSupport;
-
-import software.amazon.awssdk.services.s3.model.Grant;
-import software.amazon.awssdk.services.s3.model.Owner;
-import software.amazon.awssdk.services.s3.model.Permission;
-import software.amazon.awssdk.utils.StringUtils;
-import static java.lang.String.format;
 
 public class S3AccessControlList
 {
@@ -18,37 +10,11 @@ public class S3AccessControlList
 
     private final String key;
 
-    private final Iterable<Grant> grants;
-
-    private final Owner owner;
-
     public S3AccessControlList(final String fileStoreName,
-                               final String key,
-                               final Iterable<Grant> grants,
-                               final Owner owner)
+                               final String key)
     {
         this.fileStoreName = fileStoreName;
-        this.grants = grants;
         this.key = key;
-        this.owner = owner;
-    }
-
-    public String getKey()
-    {
-        return key;
-    }
-
-    /**
-     * have almost one of the permission set in the parameter permissions
-     *
-     * @param permissions almost one
-     * @return
-     */
-    private boolean hasPermission(final EnumSet<Permission> permissions)
-    {
-        return StreamSupport.stream(grants.spliterator(), false)
-                            .anyMatch(grant -> StringUtils.equals(grant.grantee().id(), owner.id()) &&
-                                               permissions.contains(grant.permission()));
     }
 
     public void checkAccess(final AccessMode[] modes)
@@ -56,23 +22,12 @@ public class S3AccessControlList
     {
         for (AccessMode accessMode : modes)
         {
+            // Checking the ACL grants is not sufficient to determine access as bucket policy may override ACL.
+            // Any permission problems will have to be handled at time of access.
             switch (accessMode)
             {
                 case EXECUTE:
                     throw new AccessDeniedException(fileName(), null, "file is not executable");
-                case READ:
-                    if (!hasPermission(EnumSet.of(Permission.FULL_CONTROL, Permission.READ)))
-                    {
-                        throw new AccessDeniedException(fileName(), null, "file is not readable");
-                    }
-                    break;
-                case WRITE:
-                    if (!hasPermission(EnumSet.of(Permission.FULL_CONTROL, Permission.WRITE)))
-                    {
-                        throw new AccessDeniedException(fileName(), null,
-                                                        format("bucket '%s' is not writable", fileStoreName));
-                    }
-                    break;
             }
         }
     }

--- a/src/main/java/org/carlspring/cloud/storage/s3fs/S3AccessControlList.java
+++ b/src/main/java/org/carlspring/cloud/storage/s3fs/S3AccessControlList.java
@@ -3,6 +3,9 @@ package org.carlspring.cloud.storage.s3fs;
 import java.nio.file.AccessDeniedException;
 import java.nio.file.AccessMode;
 
+import software.amazon.awssdk.services.s3.model.Grant;
+import software.amazon.awssdk.services.s3.model.Owner;
+
 public class S3AccessControlList
 {
 
@@ -10,11 +13,42 @@ public class S3AccessControlList
 
     private final String key;
 
+
+    /**
+     * Creates a new S3AccessControlList
+     *
+     * @param fileStoreName
+     * @param key
+     * @param grants unused
+     * @param owner unused
+     * @deprecated use {@link #S3AccessControlList(String, String)}
+     */
+    @Deprecated
     public S3AccessControlList(final String fileStoreName,
-                               final String key)
+                               final String key,
+                               final Iterable<Grant> grants, //unused, but keeping to preserve signature
+                               final Owner owner //unused, but keeping to preserve signature
+    )
     {
         this.fileStoreName = fileStoreName;
         this.key = key;
+    }
+
+    /**
+     * Creates a new S3AccessControlList
+     *
+     * @param fileStoreName
+     * @param key
+     */
+    public S3AccessControlList(final String fileStoreName, final String key)
+    {
+        this.fileStoreName = fileStoreName;
+        this.key = key;
+    }
+
+    public String getKey()
+    {
+        return key;
     }
 
     public void checkAccess(final AccessMode[] modes)

--- a/src/main/java/org/carlspring/cloud/storage/s3fs/S3AccessControlList.java
+++ b/src/main/java/org/carlspring/cloud/storage/s3fs/S3AccessControlList.java
@@ -28,7 +28,7 @@ public class S3AccessControlList
                                final String key,
                                final Iterable<Grant> grants, //unused, but keeping to preserve signature
                                final Owner owner //unused, but keeping to preserve signature
-    )
+                               )
     {
         this.fileStoreName = fileStoreName;
         this.key = key;

--- a/src/main/java/org/carlspring/cloud/storage/s3fs/S3AccessControlList.java
+++ b/src/main/java/org/carlspring/cloud/storage/s3fs/S3AccessControlList.java
@@ -62,7 +62,6 @@ public class S3AccessControlList
             {
                 throw new AccessDeniedException(fileName(), null, "file is not executable");
             }
-            }
         }
     }
 

--- a/src/main/java/org/carlspring/cloud/storage/s3fs/S3FileSystemProvider.java
+++ b/src/main/java/org/carlspring/cloud/storage/s3fs/S3FileSystemProvider.java
@@ -944,7 +944,8 @@ public class S3FileSystemProvider
         Preconditions.checkArgument(unsupported.isEmpty(), "the following options are not supported: %s", unsupported);
     }
 
-    private static boolean isBucketRoot(S3Path s3Path) {
+    private static boolean isBucketRoot(S3Path s3Path)
+    {
         String key = s3Path.getKey();
         return key.equals("") || key.equals("/");
     }
@@ -959,12 +960,16 @@ public class S3FileSystemProvider
     {
         S3Path s3Path = toS3Path(path);
 
-        if(isBucketRoot(s3Path)) {
+        if(isBucketRoot(s3Path))
+        {
             // check to see if bucket exists
-            try {
+            try
+            {
                 s3Utils.listS3Objects(s3Path);
                 return true;
-            } catch (SdkException e) {
+            }
+            catch (SdkException e)
+            {
                 return false;
             }
         }

--- a/src/main/java/org/carlspring/cloud/storage/s3fs/util/S3Utils.java
+++ b/src/main/java/org/carlspring/cloud/storage/s3fs/util/S3Utils.java
@@ -56,7 +56,6 @@ public class S3Utils
      */
     public List<S3Object> listS3Objects(S3Path s3Path)
     {
-
         final String key = s3Path.getKey();
         final String bucketName = s3Path.getFileStore().name();
         final S3Client client = s3Path.getFileSystem().getClient();

--- a/src/main/java/org/carlspring/cloud/storage/s3fs/util/S3Utils.java
+++ b/src/main/java/org/carlspring/cloud/storage/s3fs/util/S3Utils.java
@@ -16,6 +16,7 @@ import com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import software.amazon.awssdk.core.exception.SdkClientException;
+import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.GetObjectAclRequest;
 import software.amazon.awssdk.services.s3.model.GetObjectAclResponse;
@@ -23,7 +24,7 @@ import software.amazon.awssdk.services.s3.model.Grant;
 import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
 import software.amazon.awssdk.services.s3.model.HeadObjectResponse;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
-import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.NoSuchBucketException;
 import software.amazon.awssdk.services.s3.model.Owner;
 import software.amazon.awssdk.services.s3.model.Permission;
 import software.amazon.awssdk.services.s3.model.S3Exception;
@@ -37,6 +38,44 @@ public class S3Utils
 {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(S3Utils.class);
+
+    /**
+     * Returns a list of {@link S3Object}s for the given path.
+     *
+     * @param s3Path {@link S3Path}
+     * @return {@link List} of {@link S3Object}
+     * @throws NoSuchBucketException
+     *     The specified bucket does not exist.
+     * @throws SdkException
+     *    Base class for all exceptions that can be thrown by the SDK (both service and client). Can be used for
+     *    catch all scenarios.
+     * @throws SdkClientException
+     *     If any client side error occurs such as an IO related failure, failure to get credentials, etc.
+     * @throws S3Exception
+     *     Base class for all service exceptions.
+     */
+    public List<S3Object> listS3Objects(S3Path s3Path)
+    {
+
+        final String key = s3Path.getKey();
+        final String bucketName = s3Path.getFileStore().name();
+        final S3Client client = s3Path.getFileSystem().getClient();
+
+        // is a virtual directory
+        String keyFolder = key;
+        if (!keyFolder.endsWith("/"))
+        {
+            keyFolder += "/";
+        }
+
+        final ListObjectsV2Request request = ListObjectsV2Request.builder()
+            .bucket(bucketName)
+            .prefix(keyFolder)
+            .maxKeys(1)
+            .build();
+
+        return client.listObjectsV2(request).contents();
+    }
 
     /**
      * Get the {@link S3Object} that represent this Path or her first child if this path not exists
@@ -95,23 +134,10 @@ public class S3Utils
         // try to find the element as a directory.
         try
         {
-            // is a virtual directory
-            String keyFolder = key;
-            if (!keyFolder.endsWith("/"))
+            List<S3Object> s3Objects = listS3Objects(s3Path);
+            if (!s3Objects.isEmpty())
             {
-                keyFolder += "/";
-            }
-
-            final ListObjectsV2Request request = ListObjectsV2Request.builder()
-                                                                     .bucket(bucketName)
-                                                                     .prefix(keyFolder)
-                                                                     .maxKeys(1)
-                                                                     .build();
-
-            final ListObjectsV2Response current = client.listObjectsV2(request);
-            if (!current.contents().isEmpty())
-            {
-                return current.contents().get(0);
+                return s3Objects.get(0);
             }
         }
         catch (Exception e)

--- a/src/main/java/org/carlspring/cloud/storage/s3fs/util/S3Utils.java
+++ b/src/main/java/org/carlspring/cloud/storage/s3fs/util/S3Utils.java
@@ -69,10 +69,10 @@ public class S3Utils
         }
 
         final ListObjectsV2Request request = ListObjectsV2Request.builder()
-            .bucket(bucketName)
-            .prefix(keyFolder)
-            .maxKeys(1)
-            .build();
+                                                                 .bucket(bucketName)
+                                                                 .prefix(keyFolder)
+                                                                 .maxKeys(1)
+                                                                 .build();
 
         return client.listObjectsV2(request).contents();
     }

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/fileSystemProvider/CheckAccessTest.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/fileSystemProvider/CheckAccessTest.java
@@ -95,7 +95,7 @@ class CheckAccessTest
 
         // We're expecting an exception here to be thrown
         final Exception exception = assertThrows(NoSuchFileException.class,
-            () -> s3fsProvider.checkAccess(file1, AccessMode.WRITE));
+                                                 () -> s3fsProvider.checkAccess(file1, AccessMode.WRITE));
 
         assertNotNull(exception);
     }

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/fileSystemProvider/CheckAccessTest.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/fileSystemProvider/CheckAccessTest.java
@@ -82,7 +82,7 @@ class CheckAccessTest
 
     @Test
     void checkAccessMissingFile()
-        throws IOException
+            throws IOException
     {
         // fixtures
         final S3ClientMock client = S3MockFactory.getS3ClientMock();


### PR DESCRIPTION
# Pull Request Description

Using ACLs to check for object access is not sufficient.  The bucket policy can override the ACL.  This can be a problem when accessing a public bucket in a different account where ACLs are not configured.   In general, AWS recommends using bucket policies over ACLs.  

These changes remove the ACL check and simply check if object exists for the given user.  If that user cannot read or write to that object, an error will happen at the time of that action.

# Acceptance Test

* [x] Building the code with `mvn clean install -Pintegration-tests` still works.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see [provide details here]
  * [x] No
