### PR TITLE
Fixes url encoding for paths.

### DIFF
--- a/src/main/java/org/carlspring/cloud/storage/s3fs/S3Path.java
+++ b/src/main/java/org/carlspring/cloud/storage/s3fs/S3Path.java
@@ -7,6 +7,7 @@ import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URL;
 import java.net.URLDecoder;
+import java.net.URLEncoder;
 import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.WatchEvent;
@@ -735,11 +736,20 @@ public class S3Path
      */
     private String encode(String uri)
     {
-        // remove special case URI starting with //
-        uri = uri.replace("//", "/");
-        uri = uri.replaceAll(" ", "%20");
-
-        return uri;
+        try
+        {
+            // URL encode all characters, but then convert known allowed characters back
+            return URLEncoder.encode(uri, "UTF-8")
+                    .replace("%3A", ":")
+                    .replace("%2F", "/")
+                    .replace("+", "%20");
+        }
+        catch (UnsupportedEncodingException e)
+        {
+            // This should never happen unless there is something
+            // fundamentally broken with the running JVM.
+            throw new RuntimeException(e);
+        }
     }
 
     /**

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/path/ToUriTest.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/path/ToUriTest.java
@@ -59,6 +59,26 @@ class ToUriTest
     }
 
     @Test
+    public void toUriSpecialChars()
+    {
+        Path path = getPath("/bucket/([fol! @#$%der])");
+        URI uri = path.toUri();
+
+        // the scheme is s3
+        assertEquals("s3", uri.getScheme());
+
+        // could get the correct fileSystem
+        S3FileSystem fs = s3fsProvider.getFileSystem(uri);
+        // the host is the endpoint specified in fileSystem
+        assertEquals(fs.getEndpoint(), uri.getHost());
+
+        // bucket name as first path
+        Path pathActual = fs.provider().getPath(uri);
+
+        assertEquals(path, pathActual);
+    }
+
+    @Test
     void toUriWithEndSlash()
     {
         S3Path s3Path = getPath("/bucket/folder/");


### PR DESCRIPTION
Run the uri through URLEncoder.encode and then converting allowable characters :, / and [space] back. Taken from https://github.com/aws/aws-sdk-java/blob/master/aws-java-sdk-s3/src/main/java/com/amazonaws/services/s3/AmazonS3URI.java

# Pull Request Description

This pull request closes https://github.com/Upplication/Amazon-S3-FileSystem-NIO2/pull/117 and addresses one of the items in #72

# Acceptance Test

* [x] Building the code with `mvn clean install -Pintegration-tests` still works.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see [provide details here]
  * [x] No
