### PR TITLE
Integration tests should use distinguishable directories when creating resources in S3

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,7 @@ env:
   EVENT_NAME: ${{ toJSON(github.event_name) }}
   # format: username:branch
   PR_HEAD_LABEL: ${{ toJSON(github.event.pull_request.head.label) }}
+  PR_NUMBER: ${{ github.event.number }}
 
 jobs:
   build-matrix:

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/BaseIntegrationTest.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/BaseIntegrationTest.java
@@ -1,9 +1,16 @@
-package org.carlspring.cloud.storage.s3fs.util;
+package org.carlspring.cloud.storage.s3fs;
+
+
+import org.carlspring.cloud.storage.s3fs.util.EnvironmentBuilder;
+import org.carlspring.cloud.storage.s3fs.util.MinioContainer;
 
 import static org.carlspring.cloud.storage.s3fs.S3Factory.ACCESS_KEY;
 import static org.carlspring.cloud.storage.s3fs.S3Factory.SECRET_KEY;
 
-public abstract class BaseIntegrationTest
+/**
+ * This abstract class holds common integration test logic.
+ */
+public abstract class BaseIntegrationTest extends BaseTest
 {
 
     static

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/BaseIntegrationTest.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/BaseIntegrationTest.java
@@ -1,6 +1,5 @@
 package org.carlspring.cloud.storage.s3fs;
 
-
 import org.carlspring.cloud.storage.s3fs.util.EnvironmentBuilder;
 import org.carlspring.cloud.storage.s3fs.util.MinioContainer;
 

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/BaseTest.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/BaseTest.java
@@ -1,0 +1,148 @@
+package org.carlspring.cloud.storage.s3fs;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
+import java.util.List;
+import java.util.UUID;
+import java.util.stream.Collectors;
+
+import ch.qos.logback.classic.pattern.TargetLengthBasedClassNameAbbreviator;
+import org.junit.jupiter.api.Test;
+import static java.util.UUID.randomUUID;
+
+/**
+ * This test is meant to hold common test case logic which can be used in general for unit and integration tests.
+ */
+public abstract class BaseTest
+{
+
+    public static final String PR_NUMBER_ENV_VAR = "PR_NUMBER";
+
+    /**
+     * This is a helper method which can be used to generate "base" paths so that the created resources in S3 / MinIO
+     * can be easily tracked to the test case class and method that created them. It will try to process the stack trace
+     * and find a class which has been annotated with {@link Test} which will be used to form the path.
+     *
+     * @return abbreviated fully-qualified class name and method (i.e. o.c.c.s.s.u.BaseIntegrationTest/methodName) or
+     * <b>null</b> if it can't find .
+     */
+    protected String getTestBasePath()
+    {
+        // Filter out noise and leave only `org.carlspring.cloud.storage.s3fs` calls in the stack trace.
+        List<StackTraceElement> elements = Arrays.stream(Thread.currentThread().getStackTrace())
+                                                 .filter(e -> {
+                                                     String basePackage = BaseTest.class.getPackage().getName();
+                                                     String packageName = null;
+
+                                                     try
+                                                     {
+                                                         packageName = Class.forName(e.getClassName())
+                                                                            .getPackage()
+                                                                            .getName();
+                                                     }
+                                                     catch (ClassNotFoundException classNotFoundException)
+                                                     {
+                                                         classNotFoundException.printStackTrace();
+                                                     }
+
+                                                     return packageName != null && packageName.startsWith(basePackage);
+                                                 })
+                                                 .collect(Collectors.toList());
+
+        if(elements.size() > 0)
+        {
+            StackTraceElement last = elements.get(elements.size() - 1);
+            String className = last.getClassName();
+            String methodName = last.getMethodName();
+            try
+            {
+                Class<?> clazz = Class.forName(className);
+                int modifiers = clazz.getModifiers();
+                boolean isAbstract = Modifier.isAbstract(modifiers);
+
+                if(!isAbstract)
+                {
+                    Method method = clazz.getDeclaredMethod(methodName);
+                    Test hasTestAnnotation = method.getDeclaredAnnotation(Test.class);
+                    if(hasTestAnnotation != null)
+                    {
+                        // Additional prefix after the class name for better differentiation.
+                        String prNumber = System.getenv(PR_NUMBER_ENV_VAR);
+                        prNumber = prNumber != null ? "-pr-" + prNumber : "";
+                        return abbreviateClassName(className) + prNumber + "/" + methodName;
+                    }
+                }
+            }
+            catch (ClassNotFoundException|NoSuchMethodException e)
+            {
+                e.printStackTrace();
+            }
+
+        }
+
+        return null;
+    }
+
+    /**
+     * @param subPath The path to append
+     *
+     * @return o.c.c.s.s.u.BaseIntegrationTest/methodName/subPath
+     */
+    protected String getTestBasePath(String subPath)
+    {
+        String basePath = getTestBasePath();
+
+        if (basePath != null)
+        {
+            return basePath + "/" + subPath;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param clazz
+     *
+     * @return
+     */
+    protected String getTestBasePath(Class<?> clazz,
+                                     String methodName)
+    {
+        return abbreviateClassName(clazz.getName()) + "/" + methodName;
+    }
+
+    /**
+     * @return o.c.c.s.s.u.BaseIntegrationTest/methodName/UUID
+     */
+    protected String getTestBasePathWithUUID()
+    {
+        return getTestBasePath(randomUUID().toString());
+    }
+
+    /**
+     * This method can be used for corner cases where {@link BaseTest#getTestBasePathWithUUID} is unable to calculate
+     * the value or more flexibility is needed.
+     *
+     * @param clazz
+     * @param methodName
+     *
+     * @return
+     */
+    protected String getTestBasePathWithUUID(Class<?> clazz,
+                                             String methodName)
+    {
+        return getTestBasePath(clazz, methodName) + "/" + UUID.randomUUID();
+    }
+
+    /**
+     * @param fqClassName Fully-qualified class name
+     *
+     * @return abbreviated version of the fully-qualified class name (i.e. o.c.c.s.s.u.BaseIntegrationTest)
+     */
+    private String abbreviateClassName(String fqClassName)
+    {
+        return new TargetLengthBasedClassNameAbbreviator(5).abbreviate(fqClassName);
+    }
+
+}

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/BaseTest.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/BaseTest.java
@@ -50,7 +50,7 @@ public abstract class BaseTest
                                                  })
                                                  .collect(Collectors.toList());
 
-        if(elements.size() > 0)
+        if (elements.size() > 0)
         {
             StackTraceElement last = elements.get(elements.size() - 1);
             String className = last.getClassName();
@@ -61,11 +61,11 @@ public abstract class BaseTest
                 int modifiers = clazz.getModifiers();
                 boolean isAbstract = Modifier.isAbstract(modifiers);
 
-                if(!isAbstract)
+                if (!isAbstract)
                 {
                     Method method = clazz.getDeclaredMethod(methodName);
                     Test hasTestAnnotation = method.getDeclaredAnnotation(Test.class);
-                    if(hasTestAnnotation != null)
+                    if (hasTestAnnotation != null)
                     {
                         // Additional prefix after the class name for better differentiation.
                         String prNumber = System.getenv(PR_NUMBER_ENV_VAR);

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/FileSystemsIT.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/FileSystemsIT.java
@@ -1,7 +1,6 @@
 package org.carlspring.cloud.storage.s3fs;
 
 import org.carlspring.cloud.storage.s3fs.junit.annotations.S3IntegrationTest;
-import org.carlspring.cloud.storage.s3fs.util.BaseIntegrationTest;
 import org.carlspring.cloud.storage.s3fs.util.EnvironmentBuilder;
 
 import java.io.IOException;

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/FilesIT.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/FilesIT.java
@@ -1,7 +1,6 @@
 package org.carlspring.cloud.storage.s3fs;
 
 import org.carlspring.cloud.storage.s3fs.junit.annotations.S3IntegrationTest;
-import org.carlspring.cloud.storage.s3fs.util.BaseIntegrationTest;
 import org.carlspring.cloud.storage.s3fs.util.CopyDirVisitor;
 import org.carlspring.cloud.storage.s3fs.util.EnvironmentBuilder;
 
@@ -71,7 +70,7 @@ class FilesIT extends BaseIntegrationTest
     @Test
     void notExistsDir()
     {
-        Path dir = fileSystemAmazon.getPath(bucket, UUID.randomUUID().toString() + "/");
+        Path dir = fileSystemAmazon.getPath(bucket, getTestBasePathWithUUID() + "/");
 
         assertFalse(Files.exists(dir));
     }
@@ -79,7 +78,7 @@ class FilesIT extends BaseIntegrationTest
     @Test
     void notExistsFile()
     {
-        Path file = fileSystemAmazon.getPath(bucket, UUID.randomUUID().toString());
+        Path file = fileSystemAmazon.getPath(bucket, getTestBasePathWithUUID());
 
         assertFalse(Files.exists(file));
     }
@@ -88,7 +87,7 @@ class FilesIT extends BaseIntegrationTest
     void existsFile()
             throws IOException
     {
-        Path file = fileSystemAmazon.getPath(bucket, UUID.randomUUID().toString());
+        Path file = fileSystemAmazon.getPath(bucket, getTestBasePathWithUUID());
 
         EnumSet<StandardOpenOption> options = EnumSet.of(StandardOpenOption.CREATE_NEW, StandardOpenOption.WRITE);
 
@@ -101,7 +100,7 @@ class FilesIT extends BaseIntegrationTest
     void existsFileWithSpace()
             throws IOException
     {
-        Path file = fileSystemAmazon.getPath(bucket, UUID.randomUUID().toString(), "space folder");
+        Path file = fileSystemAmazon.getPath(bucket, getTestBasePathWithUUID(), "space folder");
 
         Files.createDirectories(file);
 
@@ -224,7 +223,7 @@ class FilesIT extends BaseIntegrationTest
     void directoryStreamBaseBucketFindDirectoryTest()
             throws IOException
     {
-        Path bucketPath = fileSystemAmazon.getPath(bucket);
+        Path bucketPath = fileSystemAmazon.getPath(bucket, getTestBasePathWithUUID() + "/");
         String name = "01" + UUID.randomUUID().toString();
 
         final Path fileToFind = Files.createDirectory(bucketPath.resolve(name));
@@ -239,7 +238,7 @@ class FilesIT extends BaseIntegrationTest
     void directoryStreamBaseBucketFindFileTest()
             throws IOException
     {
-        Path bucketPath = fileSystemAmazon.getPath(bucket);
+        Path bucketPath = fileSystemAmazon.getPath(bucket, getTestBasePathWithUUID() + "/");
         String name = "00" + UUID.randomUUID().toString();
 
         final Path fileToFind = Files.createFile(bucketPath.resolve(name));
@@ -277,12 +276,12 @@ class FilesIT extends BaseIntegrationTest
     void virtualDirectoryStreamTest()
             throws IOException
     {
-        String folder = UUID.randomUUID().toString() + "/";
+        String folder = getTestBasePathWithUUID() + "/" + UUID.randomUUID().toString() + "/";
+
+        Path dir = fileSystemAmazon.getPath(bucket, folder);
 
         String file1 = folder + "file.html";
         String file2 = folder + "file2.html";
-
-        Path dir = fileSystemAmazon.getPath(bucket, folder);
 
         S3Path s3Path = (S3Path) dir;
         final S3Client client = s3Path.getFileSystem().getClient();
@@ -337,7 +336,7 @@ class FilesIT extends BaseIntegrationTest
     void virtualDirectoryStreamWithVirtualSubFolderTest()
             throws IOException
     {
-        String folder = UUID.randomUUID().toString() + "/";
+        String folder = getTestBasePathWithUUID() + "/";
 
         String subFolder = folder + "subfolder/file.html";
         String file2 = folder + "file2.html";
@@ -462,7 +461,7 @@ class FilesIT extends BaseIntegrationTest
         try (FileSystem linux = MemoryFileSystemBuilder.newLinux().build("linux"))
         {
             Path sourceLocal = Files.write(linux.getPath("/index.html"), content.getBytes());
-            Path result = fileSystemAmazon.getPath(bucket, UUID.randomUUID().toString());
+            Path result = fileSystemAmazon.getPath(bucket, getTestBasePathWithUUID());
 
             Files.move(sourceLocal, result);
 
@@ -480,7 +479,7 @@ class FilesIT extends BaseIntegrationTest
         final String content = "sample content";
 
         Path source = uploadSingleFile(content);
-        Path dest = fileSystemAmazon.getPath(bucket, UUID.randomUUID().toString());
+        Path dest = fileSystemAmazon.getPath(bucket, getTestBasePathWithUUID());
 
         Files.move(source, dest);
 
@@ -493,7 +492,7 @@ class FilesIT extends BaseIntegrationTest
     @Test
     void createFileWithFolderAndNotExistsFolders()
     {
-        String fileWithFolders = UUID.randomUUID().toString() + "/folder2/file.html";
+        String fileWithFolders = getTestBasePathWithUUID() + "/folder2/file.html";
 
         Path path = fileSystemAmazon.getPath(bucket, fileWithFolders.split("/"));
 
@@ -520,7 +519,7 @@ class FilesIT extends BaseIntegrationTest
             final Path htmlFile = Files.write(linux.getPath("/index.html"),
                                               "<html><body>html file</body></html>".getBytes());
 
-            final String fileName = UUID.randomUUID().toString() + htmlFile.getFileName().toString();
+            final String fileName = getTestBasePathWithUUID() + "/" + htmlFile.getFileName().toString();
             final Path result = fileSystemAmazon.getPath(bucket, fileName);
 
             Files.copy(htmlFile, result);
@@ -562,7 +561,7 @@ class FilesIT extends BaseIntegrationTest
         {
             final Path htmlFile = Files.write(linux.getPath("/index.adsadas"), data);
 
-            final String fileName = UUID.randomUUID().toString() + htmlFile.getFileName().toString();
+            final String fileName = getTestBasePathWithUUID() + "/" + htmlFile.getFileName().toString();
             final Path result = fileSystemAmazon.getPath(bucket, fileName);
 
             Files.copy(htmlFile, result);
@@ -588,7 +587,7 @@ class FilesIT extends BaseIntegrationTest
             final Path htmlFile = Files.write(linux.getPath("/index.html"),
                                               "<html><body>html file</body></html>".getBytes());
 
-            final String fileName = UUID.randomUUID().toString() + htmlFile.getFileName().toString();
+            final String fileName = getTestBasePathWithUUID() + "/" + htmlFile.getFileName().toString();
             final Path result = fileSystemAmazon.getPath(bucket, fileName);
 
             try (final OutputStream out = Files.newOutputStream(result))
@@ -666,7 +665,7 @@ class FilesIT extends BaseIntegrationTest
     {
         Path dir;
 
-        final String startPath = "0000example" + UUID.randomUUID().toString() + "/";
+        final String startPath = getTestBasePathWithUUID() + "/";
 
         try (FileSystem linux = MemoryFileSystemBuilder.newLinux().build("linux"))
         {
@@ -745,7 +744,7 @@ class FilesIT extends BaseIntegrationTest
     private Path createEmptyDir()
             throws IOException
     {
-        Path dir = fileSystemAmazon.getPath(bucket, UUID.randomUUID().toString() + "/");
+        Path dir = fileSystemAmazon.getPath(bucket, getTestBasePathWithUUID() + "/");
 
         Files.createDirectory(dir);
 
@@ -755,7 +754,7 @@ class FilesIT extends BaseIntegrationTest
     private Path createEmptyFile()
             throws IOException
     {
-        Path file = fileSystemAmazon.getPath(bucket, UUID.randomUUID().toString());
+        Path file = fileSystemAmazon.getPath(bucket, getTestBasePathWithUUID());
 
         Files.createFile(file);
 
@@ -776,7 +775,7 @@ class FilesIT extends BaseIntegrationTest
                 Files.createFile(linux.getPath("/index.html"));
             }
 
-            Path result = fileSystemAmazon.getPath(bucket, UUID.randomUUID().toString());
+            Path result = fileSystemAmazon.getPath(bucket, getTestBasePathWithUUID());
 
             Files.copy(linux.getPath("/index.html"), result);
 
@@ -799,7 +798,7 @@ class FilesIT extends BaseIntegrationTest
             Files.createDirectory(assets.resolve("js"));
             Files.createFile(assets.resolve("js").resolve("main.js"));
 
-            Path dir = fileSystemAmazon.getPath(bucket, "0000example" + UUID.randomUUID().toString() + "/");
+            Path dir = fileSystemAmazon.getPath(bucket, getTestBasePathWithUUID() + "/");
 
             Files.exists(assets);
             Files.walkFileTree(assets.getParent(), new CopyDirVisitor(assets.getParent(), dir));

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/S3ClientIT.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/S3ClientIT.java
@@ -1,7 +1,6 @@
 package org.carlspring.cloud.storage.s3fs;
 
 import org.carlspring.cloud.storage.s3fs.junit.annotations.S3IntegrationTest;
-import org.carlspring.cloud.storage.s3fs.util.BaseIntegrationTest;
 import org.carlspring.cloud.storage.s3fs.util.EnvironmentBuilder;
 
 import java.io.ByteArrayInputStream;
@@ -60,7 +59,7 @@ class S3ClientIT extends BaseIntegrationTest
 
         Files.write(file, "content".getBytes(), StandardOpenOption.APPEND);
 
-        PutObjectRequest request = PutObjectRequest.builder().bucket(getBucket()).key(randomUUID().toString()).build();
+        PutObjectRequest request = PutObjectRequest.builder().bucket(getBucket()).key(getTestBasePath() + "/" + randomUUID().toString()).build();
         PutObjectResponse result = client.putObject(request, file);
 
         assertNotNull(result);
@@ -74,8 +73,11 @@ class S3ClientIT extends BaseIntegrationTest
 
         Files.write(file, "content".getBytes(), StandardOpenOption.APPEND);
 
-        PutObjectRequest request = PutObjectRequest.builder().bucket(getBucket()).key(
-                randomUUID().toString() + "/").build();
+        PutObjectRequest request = PutObjectRequest.builder()
+                                                   .bucket(getBucket())
+                                                   .key(getTestBasePathWithUUID() + "/")
+                                                   .build();
+
         PutObjectResponse result = client.putObject(request, file);
 
         assertNotNull(result);
@@ -89,7 +91,11 @@ class S3ClientIT extends BaseIntegrationTest
 
         Files.write(file, "content".getBytes(), StandardOpenOption.APPEND);
 
-        PutObjectRequest request = PutObjectRequest.builder().bucket(getBucket()).key("/" + randomUUID().toString()).build();
+        PutObjectRequest request = PutObjectRequest.builder()
+                                                   .bucket(getBucket())
+                                                   .key("/" + getTestBasePathWithUUID())
+                                                   .build();
+
         PutObjectResponse result = client.putObject(request, file);
 
         assertNotNull(result);
@@ -103,7 +109,11 @@ class S3ClientIT extends BaseIntegrationTest
 
         Files.write(file, "content".getBytes(), StandardOpenOption.APPEND);
 
-        PutObjectRequest request = PutObjectRequest.builder().bucket(getBucket()).key("/" + randomUUID().toString() + "/").build();
+        PutObjectRequest request = PutObjectRequest.builder()
+                                                   .bucket(getBucket())
+                                                   .key("/" + getTestBasePathWithUUID() + "/")
+                                                   .build();
+
         PutObjectResponse result = client.putObject(request, file);
 
         assertNotNull(result);
@@ -115,7 +125,11 @@ class S3ClientIT extends BaseIntegrationTest
     {
         final InputStream inputStream = new ByteArrayInputStream("contents1".getBytes());
         final RequestBody requestBody = RequestBody.fromInputStream(inputStream, inputStream.available());
-        PutObjectRequest request = PutObjectRequest.builder().bucket(getBucket()).key(randomUUID().toString()).build();
+        PutObjectRequest request = PutObjectRequest.builder()
+                                                   .bucket(getBucket())
+                                                   .key(getTestBasePathWithUUID())
+                                                   .build();
+
         PutObjectResponse result = client.putObject(request, requestBody);
 
         assertNotNull(result);

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/S3UnitTestBase.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/S3UnitTestBase.java
@@ -17,13 +17,12 @@ import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.spy;
 
-public class S3UnitTestBase
+public abstract class S3UnitTestBase extends BaseTest
 {
 
     protected S3FileSystemProvider s3fsProvider;
 
     protected FileSystem fileSystem;
-
 
     @BeforeEach
     public void setProperties()

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/S3UtilsIT.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/S3UtilsIT.java
@@ -3,7 +3,6 @@ package org.carlspring.cloud.storage.s3fs;
 import org.carlspring.cloud.storage.s3fs.attribute.S3BasicFileAttributes;
 import org.carlspring.cloud.storage.s3fs.attribute.S3PosixFileAttributes;
 import org.carlspring.cloud.storage.s3fs.junit.annotations.S3IntegrationTest;
-import org.carlspring.cloud.storage.s3fs.util.BaseIntegrationTest;
 import org.carlspring.cloud.storage.s3fs.util.CopyDirVisitor;
 import org.carlspring.cloud.storage.s3fs.util.EnvironmentBuilder;
 import org.carlspring.cloud.storage.s3fs.util.S3Utils;
@@ -22,6 +21,8 @@ import java.util.UUID;
 import com.github.marschall.memoryfilesystem.MemoryFileSystemBuilder;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.Execution;
+import org.junit.jupiter.api.parallel.ExecutionMode;
 import software.amazon.awssdk.core.sync.RequestBody;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
@@ -36,6 +37,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @S3IntegrationTest
+@Execution(ExecutionMode.CONCURRENT)
 class S3UtilsIT extends BaseIntegrationTest
 {
 
@@ -96,7 +98,7 @@ class S3UtilsIT extends BaseIntegrationTest
     {
         Path path;
 
-        final String startPath = "0000example" + UUID.randomUUID().toString() + "/";
+        final String startPath = getTestBasePath() + "/" + UUID.randomUUID().toString() + "/";
 
         try (FileSystem linux = MemoryFileSystemBuilder.newLinux().build("linux"))
         {
@@ -122,7 +124,7 @@ class S3UtilsIT extends BaseIntegrationTest
     {
         Path path;
 
-        final String startPath = "0000example" + UUID.randomUUID().toString() + "/";
+        final String startPath = getTestBasePath() + "/" + UUID.randomUUID().toString() + "/";
 
         try (FileSystem linux = MemoryFileSystemBuilder.newLinux().build("linux"))
         {
@@ -143,7 +145,7 @@ class S3UtilsIT extends BaseIntegrationTest
     void lookupS3ObjectWhenS3PathIsADirectoryAndExistsOtherDirectoryStartsSameName()
             throws IOException
     {
-        final String startPath = "0000example" + UUID.randomUUID().toString() + "/";
+        final String startPath = getTestBasePath() + "/" + UUID.randomUUID().toString() + "/";
 
         S3FileSystem s3FileSystem = (S3FileSystem) fileSystemAmazon;
 
@@ -168,7 +170,7 @@ class S3UtilsIT extends BaseIntegrationTest
     void lookupS3ObjectWhenS3PathIsADirectoryAndIsVirtual()
             throws IOException
     {
-        String folder = "angular" + UUID.randomUUID().toString();
+        String folder = getTestBasePath() + "/angular/" + UUID.randomUUID().toString();
         String key = folder + "/content.js";
 
         final ByteArrayInputStream inputStream = new ByteArrayInputStream("content1".getBytes());
@@ -211,7 +213,7 @@ class S3UtilsIT extends BaseIntegrationTest
     void lookupS3BasicFileAttributesWhenS3PathIsADirectoryAndIsVirtual()
             throws IOException
     {
-        String folder = "angular" + UUID.randomUUID().toString();
+        String folder = getTestBasePath() + "/angular/" + UUID.randomUUID().toString();
         String key = folder + "/content.js";
 
         S3FileSystem s3FileSystem = (S3FileSystem) fileSystemAmazon;
@@ -241,7 +243,7 @@ class S3UtilsIT extends BaseIntegrationTest
     void lookupS3BasicFileAttributesWhenS3PathIsADirectoryAndIsNotVirtualAndNoContent()
             throws IOException
     {
-        String folder = "folder" + UUID.randomUUID().toString();
+        String folder = getTestBasePath() + "/folder/" + UUID.randomUUID().toString();
         String key = folder + "/";
 
         ByteArrayInputStream inputStream = new ByteArrayInputStream("contenido1".getBytes());
@@ -299,7 +301,7 @@ class S3UtilsIT extends BaseIntegrationTest
             throws IOException
     {
         //given
-        final String folder = "angular" + UUID.randomUUID().toString();
+        final String folder = getTestBasePath() + "/angular/" + UUID.randomUUID().toString();
         final String key = folder + "/content.js";
 
         final ByteArrayInputStream inputStream = new ByteArrayInputStream("content1".getBytes());
@@ -334,7 +336,7 @@ class S3UtilsIT extends BaseIntegrationTest
             throws IOException
     {
         //given
-        final String folder = "folder" + UUID.randomUUID().toString();
+        final String folder = getTestBasePath() + "/folder/" + UUID.randomUUID().toString();
         final String key = folder + "/";
 
         final ByteArrayInputStream inputStream = new ByteArrayInputStream("".getBytes());
@@ -373,7 +375,7 @@ class S3UtilsIT extends BaseIntegrationTest
     private Path getPathFile()
             throws IOException
     {
-        final String startPath = "0000example" + UUID.randomUUID().toString() + "/";
+        final String startPath = getTestBasePath() + "/" + UUID.randomUUID().toString() + "/";
 
         Path path;
 

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/fileSystemProvider/GetFileSystemIT.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/fileSystemProvider/GetFileSystemIT.java
@@ -2,7 +2,7 @@ package org.carlspring.cloud.storage.s3fs.fileSystemProvider;
 
 import org.carlspring.cloud.storage.s3fs.S3FileSystemProvider;
 import org.carlspring.cloud.storage.s3fs.junit.annotations.S3IntegrationTest;
-import org.carlspring.cloud.storage.s3fs.util.BaseIntegrationTest;
+import org.carlspring.cloud.storage.s3fs.BaseIntegrationTest;
 
 import java.io.IOException;
 import java.nio.file.FileSystem;

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/fileSystemProvider/NewAsynchronousFileChannelTestIT.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/fileSystemProvider/NewAsynchronousFileChannelTestIT.java
@@ -205,7 +205,7 @@ class NewAsynchronousFileChannelTestIT
 
             Files.write(file, content.getBytes());
 
-            final Path result = fileSystemAmazon.getPath(bucket, UUID.randomUUID().toString());
+            final Path result = fileSystemAmazon.getPath(bucket, getTestBasePathWithUUID());
 
             Files.copy(file, result);
 
@@ -219,7 +219,7 @@ class NewAsynchronousFileChannelTestIT
         try (final FileSystem linux = MemoryFileSystemBuilder.newLinux().build("linux"))
         {
             final Path assets = Files.createDirectories(linux.getPath("/upload/assets1"));
-            final Path dir = fileSystemAmazon.getPath(bucket, "0000example" + UUID.randomUUID().toString() + "/");
+            final Path dir = fileSystemAmazon.getPath(bucket, getTestBasePathWithUUID() + "/");
 
             Files.walkFileTree(assets.getParent(), new CopyDirVisitor(assets.getParent(), dir));
 

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/fileSystemProvider/NewByteChannelIT.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/fileSystemProvider/NewByteChannelIT.java
@@ -41,7 +41,6 @@ class NewByteChannelIT
 
     private FileSystem fileSystemAmazon;
 
-
     @BeforeEach
     public void setup()
             throws IOException
@@ -170,7 +169,7 @@ class NewByteChannelIT
         }
     }
 
-    private Path uploadSingleFile(String content)
+    public Path uploadSingleFile(String content)
             throws IOException
     {
         try (FileSystem linux = MemoryFileSystemBuilder.newLinux().build("linux"))
@@ -179,7 +178,7 @@ class NewByteChannelIT
 
             Files.write(file, content.getBytes());
 
-            Path result = fileSystemAmazon.getPath(bucket, UUID.randomUUID().toString());
+            Path result = fileSystemAmazon.getPath(bucket, getTestBasePathWithUUID());
 
             Files.copy(file, result);
 
@@ -193,7 +192,7 @@ class NewByteChannelIT
         try (FileSystem linux = MemoryFileSystemBuilder.newLinux().build("linux"))
         {
             Path assets = Files.createDirectories(linux.getPath("/upload/assets1"));
-            Path dir = fileSystemAmazon.getPath(bucket, "0000example" + UUID.randomUUID().toString() + "/");
+            Path dir = fileSystemAmazon.getPath(bucket, getTestBasePathWithUUID() + "/");
 
             Files.walkFileTree(assets.getParent(), new CopyDirVisitor(assets.getParent(), dir));
 

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/fileSystemProvider/NewFileSystemIT.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/fileSystemProvider/NewFileSystemIT.java
@@ -2,7 +2,7 @@ package org.carlspring.cloud.storage.s3fs.fileSystemProvider;
 
 import org.carlspring.cloud.storage.s3fs.S3FileSystemProvider;
 import org.carlspring.cloud.storage.s3fs.junit.annotations.S3IntegrationTest;
-import org.carlspring.cloud.storage.s3fs.util.BaseIntegrationTest;
+import org.carlspring.cloud.storage.s3fs.BaseIntegrationTest;
 
 import java.io.IOException;
 import java.net.URI;

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/junit/examples/CombinedIT.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/junit/examples/CombinedIT.java
@@ -2,7 +2,7 @@ package org.carlspring.cloud.storage.s3fs.junit.examples;
 
 import org.carlspring.cloud.storage.s3fs.junit.annotations.MinioIntegrationTest;
 import org.carlspring.cloud.storage.s3fs.junit.annotations.S3IntegrationTest;
-import org.carlspring.cloud.storage.s3fs.util.BaseIntegrationTest;
+import org.carlspring.cloud.storage.s3fs.BaseIntegrationTest;
 
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/junit/examples/CombinedMinioS3IT.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/junit/examples/CombinedMinioS3IT.java
@@ -2,7 +2,7 @@ package org.carlspring.cloud.storage.s3fs.junit.examples;
 
 import org.carlspring.cloud.storage.s3fs.junit.annotations.MinioIntegrationTest;
 import org.carlspring.cloud.storage.s3fs.junit.annotations.S3IntegrationTest;
-import org.carlspring.cloud.storage.s3fs.util.BaseIntegrationTest;
+import org.carlspring.cloud.storage.s3fs.BaseIntegrationTest;
 
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/junit/examples/CombinedS3MinioIT.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/junit/examples/CombinedS3MinioIT.java
@@ -2,7 +2,7 @@ package org.carlspring.cloud.storage.s3fs.junit.examples;
 
 import org.carlspring.cloud.storage.s3fs.junit.annotations.MinioIntegrationTest;
 import org.carlspring.cloud.storage.s3fs.junit.annotations.S3IntegrationTest;
-import org.carlspring.cloud.storage.s3fs.util.BaseIntegrationTest;
+import org.carlspring.cloud.storage.s3fs.BaseIntegrationTest;
 
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/junit/examples/MinioClassAnnotationIT.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/junit/examples/MinioClassAnnotationIT.java
@@ -1,7 +1,7 @@
 package org.carlspring.cloud.storage.s3fs.junit.examples;
 
 import org.carlspring.cloud.storage.s3fs.junit.annotations.MinioIntegrationTest;
-import org.carlspring.cloud.storage.s3fs.util.BaseIntegrationTest;
+import org.carlspring.cloud.storage.s3fs.BaseIntegrationTest;
 
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/junit/examples/MinioMethodAnnotationIT.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/junit/examples/MinioMethodAnnotationIT.java
@@ -1,7 +1,7 @@
 package org.carlspring.cloud.storage.s3fs.junit.examples;
 
 import org.carlspring.cloud.storage.s3fs.junit.annotations.MinioIntegrationTest;
-import org.carlspring.cloud.storage.s3fs.util.BaseIntegrationTest;
+import org.carlspring.cloud.storage.s3fs.BaseIntegrationTest;
 
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/junit/examples/S3ClassAnnotationIT.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/junit/examples/S3ClassAnnotationIT.java
@@ -1,7 +1,7 @@
 package org.carlspring.cloud.storage.s3fs.junit.examples;
 
 import org.carlspring.cloud.storage.s3fs.junit.annotations.S3IntegrationTest;
-import org.carlspring.cloud.storage.s3fs.util.BaseIntegrationTest;
+import org.carlspring.cloud.storage.s3fs.BaseIntegrationTest;
 
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/junit/examples/S3MethodAnnotationIT.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/junit/examples/S3MethodAnnotationIT.java
@@ -1,7 +1,7 @@
 package org.carlspring.cloud.storage.s3fs.junit.examples;
 
 import org.carlspring.cloud.storage.s3fs.junit.annotations.S3IntegrationTest;
-import org.carlspring.cloud.storage.s3fs.util.BaseIntegrationTest;
+import org.carlspring.cloud.storage.s3fs.BaseIntegrationTest;
 
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/path/ToURLIT.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/path/ToURLIT.java
@@ -3,7 +3,7 @@ package org.carlspring.cloud.storage.s3fs.path;
 import org.carlspring.cloud.storage.s3fs.S3FileSystemProvider;
 import org.carlspring.cloud.storage.s3fs.S3Path;
 import org.carlspring.cloud.storage.s3fs.junit.annotations.S3IntegrationTest;
-import org.carlspring.cloud.storage.s3fs.util.BaseIntegrationTest;
+import org.carlspring.cloud.storage.s3fs.BaseIntegrationTest;
 import org.carlspring.cloud.storage.s3fs.util.EnvironmentBuilder;
 
 import java.io.IOException;

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/spike/EnvironmentIT.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/spike/EnvironmentIT.java
@@ -2,7 +2,7 @@ package org.carlspring.cloud.storage.s3fs.spike;
 
 import org.carlspring.cloud.storage.s3fs.junit.annotations.MinioIntegrationTest;
 import org.carlspring.cloud.storage.s3fs.junit.annotations.S3IntegrationTest;
-import org.carlspring.cloud.storage.s3fs.util.BaseIntegrationTest;
+import org.carlspring.cloud.storage.s3fs.BaseIntegrationTest;
 import org.carlspring.cloud.storage.s3fs.util.EnvironmentBuilder;
 
 import java.util.Map;

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/util/EnvironmentBuilder.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/util/EnvironmentBuilder.java
@@ -1,5 +1,7 @@
 package org.carlspring.cloud.storage.s3fs.util;
 
+import org.carlspring.cloud.storage.s3fs.BaseIntegrationTest;
+
 import javax.annotation.Nonnull;
 import java.io.IOException;
 import java.io.InputStream;


### PR DESCRIPTION
# Pull Request Description

This pull request closes #199.

# Acceptance Test

* [x] Building the code with `mvn clean install -Punit-tests,it-minio,it-s3` still works.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see [provide details here]
  * [x] No


# Screenshots

![image](https://user-images.githubusercontent.com/2303663/106554060-49b82e00-6523-11eb-9225-dea8db1ce3f7.png)
![image](https://user-images.githubusercontent.com/2303663/106554075-52a8ff80-6523-11eb-8079-9a4d1fe5ef24.png)
![image](https://user-images.githubusercontent.com/2303663/106554083-589ee080-6523-11eb-8871-3843bda8c3eb.png)
![image](https://user-images.githubusercontent.com/2303663/106554111-65bbcf80-6523-11eb-859b-c336970d1417.png)
![image](https://user-images.githubusercontent.com/2303663/106554134-6e140a80-6523-11eb-9fcc-8e5f6944feb2.png)

