### PR TITLE
Enable no-cache option when uploading a new object

### DIFF
--- a/src/main/java/org/carlspring/cloud/storage/s3fs/S3OutputStream.java
+++ b/src/main/java/org/carlspring/cloud/storage/s3fs/S3OutputStream.java
@@ -435,6 +435,7 @@ public final class S3OutputStream
         final PutObjectRequest.Builder requestBuilder = PutObjectRequest.builder()
                                                                         .bucket(objectId.getBucket())
                                                                         .key(objectId.getKey())
+                                                                        .cacheControl("no-cache")
                                                                         .contentLength(contentLength)
                                                                         .contentType(contentType)
                                                                         .metadata(metadataMap);


### PR DESCRIPTION
Not an actual pull request...
This is just an idea of what we need in Lucidworks, as discussed during our last call. I'm not sure what are all the places where the `no-cache` option needs to be added.