### PR TITLE
deps(upgrade): bump junit to 5.10.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -53,8 +53,8 @@ dependencies {
     api("com.google.code.findbugs:jsr305:3.0.2")
 
     testImplementation("ch.qos.logback:logback-classic:1.2.9")
-    testImplementation("org.junit.jupiter:junit-jupiter:5.8.1")
-    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
+    testImplementation("org.junit.jupiter:junit-jupiter:5.10.0")
+    testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.10.0")
     testImplementation("org.apache.commons:commons-lang3:3.12.0")
     testImplementation("com.github.marschall:zipfilesystem-standalone:1.0.1")
     testImplementation("com.github.marschall:memoryfilesystem:2.1.0")


### PR DESCRIPTION
# Pull Request Description

This pull request upgrade junit dependencies to 5.10.0.

# Acceptance Test

* [x] Building the code with `gradle clean build` still works.

# Questions

* Does this pull request break backward compatibility? 
  * [x] Yes and my commit follows the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/)
  * [ ] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see [provide details here]
  * [x] No
