### PR TITLE
chore(gradle): Remove duplicate testImplementation dependency

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -62,7 +62,6 @@ dependencies {
     testImplementation("org.mockito:mockito-inline:4.11.0")
     testImplementation("org.mockito:mockito-junit-jupiter:4.11.0")
     testImplementation("org.testcontainers:testcontainers:1.18.3")
-    testImplementation("org.testcontainers:testcontainers:1.18.3")
     testImplementation("org.assertj:assertj-core:3.24.2")
 }
 


### PR DESCRIPTION
# Pull Request Description

This pull request remove duplicate `org.testcontainers:testcontainers:1.18.3` dependency in `build.gradle.kts`

# Acceptance Test

* [X] Building the code with `gradle clean build` still works.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes and my commit follows the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/)
  * [X} No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [X] No

* Does this require an update of the documentation?
  * [ ] Yes, please see [provide details here]
  * [X] No
