### PR TITLE
chore(gradle): Configure tz of sdf using `apply` in `build.gradle.kts`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -121,9 +121,8 @@ tasks {
     }
 
     named<Jar>("jar") {
+        val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss zzz").apply { timeZone = TimeZone.getTimeZone("UTC") }
         val attrs = HashMap<String, String?>()
-        val sdf = SimpleDateFormat("yyyy-MM-dd HH:mm:ss zzz")
-        sdf.timeZone = TimeZone.getTimeZone("UTC")
         attrs["Build-Date"] = sdf.format(Date())
         attrs["Build-JDK"] = System.getProperty("java.version")
         attrs["Build-Gradle"] = project.gradle.gradleVersion


### PR DESCRIPTION
# Pull Request Description

This pull request configures the `timeZone` of the `SimpleDateFormat` in the same line using `apply` in `build.gradle.kts`

# Acceptance Test

* [X] Building the code with `gradle clean build` still works.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes and my commit follows the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/)
  * [X] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [X] No

* Does this require an update of the documentation?
  * [ ] Yes, please see [provide details here]
  * [X] No
