### PR TITLE
feat(fsprovider): Implement `S3FileSystemProvider.getFileStore`

### DIFF
--- a/src/main/java/org/carlspring/cloud/storage/s3fs/S3FileSystemProvider.java
+++ b/src/main/java/org/carlspring/cloud/storage/s3fs/S3FileSystemProvider.java
@@ -933,7 +933,7 @@ public class S3FileSystemProvider
     @Override
     public FileStore getFileStore(Path path)
     {
-        throw new UnsupportedOperationException();
+        return toS3Path(path).getFileStore();
     }
 
     @Override

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/FilesIT.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/FilesIT.java
@@ -74,6 +74,17 @@ class FilesIT extends BaseIntegrationTest
     }
 
     @Test
+    void fileStore()
+            throws IOException
+    {
+        Path dir = fileSystemAmazon.getPath(bucket);
+
+        FileStore fileStore = Files.getFileStore(dir);
+
+        assertInstanceOf(S3FileStore.class, fileStore);
+    }
+
+    @Test
     void notExistsDir()
     {
         Path dir = fileSystemAmazon.getPath(bucket, getTestBasePathWithUUID() + "/");

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/fileSystemProvider/GetFileStoreTest.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/fileSystemProvider/GetFileStoreTest.java
@@ -1,5 +1,6 @@
 package org.carlspring.cloud.storage.s3fs.fileSystemProvider;
 
+import org.carlspring.cloud.storage.s3fs.S3FileStore;
 import org.carlspring.cloud.storage.s3fs.S3FileSystem;
 import org.carlspring.cloud.storage.s3fs.S3UnitTestBase;
 import org.carlspring.cloud.storage.s3fs.util.S3ClientMock;
@@ -7,14 +8,15 @@ import org.carlspring.cloud.storage.s3fs.util.S3EndpointConstant;
 import org.carlspring.cloud.storage.s3fs.util.S3MockFactory;
 
 import java.io.IOException;
+import java.nio.file.FileStore;
 import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.FileSystems;
 import java.nio.file.Path;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 
 class GetFileStoreTest
         extends S3UnitTestBase
@@ -30,7 +32,7 @@ class GetFileStoreTest
     }
 
     @Test
-    void getFileStore()
+    void shouldReturnS3FileStore()
             throws IOException
     {
         // fixtures
@@ -40,10 +42,8 @@ class GetFileStoreTest
         // act
         Path file1 = createNewS3FileSystem().getPath("/bucketA/dir/file1");
 
-        // We're expecting an exception here to be thrown
-        Exception exception = assertThrows(UnsupportedOperationException.class, () -> s3fsProvider.getFileStore(file1));
-
-        assertNotNull(exception);
+        FileStore fileStore = s3fsProvider.getFileStore(file1);
+        assertInstanceOf(S3FileStore.class, fileStore);
     }
 
     /**


### PR DESCRIPTION
# Pull Request Description

This pull request implements `S3FileSystemProvider.getFileStore`. The implementation is quite simple as the `FileStore` can be taken from the `S3Path`.

As a benefit, users of the library can use `Files.getFileStore` with an `S3Path`, removing the need to have specific code to get the FileStore of an S3Path (check if is S3Path, cast to it and get fileStore).

# Acceptance Test

* [X] Building the code with `gradle clean build` still works.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes and my commit follows the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/)
  * [X] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [X] No

* Does this require an update of the documentation?
  * [ ] Yes, please see [provide details here]
  * [X] No
