### PR TITLE
chore(rewrite): Use `S3Path.getBucketName`

### DIFF
--- a/src/main/java/org/carlspring/cloud/storage/s3fs/S3FileChannel.java
+++ b/src/main/java/org/carlspring/cloud/storage/s3fs/S3FileChannel.java
@@ -125,7 +125,7 @@ public class S3FileChannel
                     {
                         final S3Client client = path.getFileSystem().getClient();
                         final GetObjectRequest request = GetObjectRequest.builder()
-                                                                         .bucket(path.getFileStore().name())
+                                                                         .bucket(path.getBucketName())
                                                                          .key(key)
                                                                          .build();
                         try (ResponseInputStream<GetObjectResponse> byteStream = client.getObject(request))
@@ -476,7 +476,7 @@ public class S3FileChannel
         {
             final PutObjectRequest.Builder builder = PutObjectRequest.builder();
             final long length = Files.size(tempFile);
-            builder.bucket(path.getFileStore().name())
+            builder.bucket(path.getBucketName())
                    .key(path.getKey())
                    .contentLength(length)
                    .contentType(new Tika().detect(stream, path.getFileName().toString()));

--- a/src/main/java/org/carlspring/cloud/storage/s3fs/S3FileSystemProvider.java
+++ b/src/main/java/org/carlspring/cloud/storage/s3fs/S3FileSystemProvider.java
@@ -524,7 +524,7 @@ public class S3FileSystemProvider
     {
         final S3Path s3Path = toS3Path(path);
         final String key = s3Path.getKey();
-        final String bucketName = s3Path.getFileStore().name();
+        final String bucketName = s3Path.getBucketName();
 
         Preconditions.checkArgument(options.length == 0,
                                     "OpenOptions not yet supported: %s",
@@ -689,7 +689,7 @@ public class S3FileSystemProvider
 
         // create bucket if necessary
         final Bucket bucket = s3Path.getFileStore().getBucket();
-        final String bucketName = s3Path.getFileStore().name();
+        final String bucketName = s3Path.getBucketName();
 
         if (bucket == null)
         {
@@ -717,7 +717,7 @@ public class S3FileSystemProvider
     {
         final S3Path rootPath = toS3Path(path);
         final S3Client client = rootPath.getFileSystem().getClient();
-        final String bucketName = rootPath.getFileStore().name();
+        final String bucketName = rootPath.getBucketName();
 
         LinkedList<Deque<S3Path>> s3Paths = getPathsByBatch(rootPath);
 
@@ -868,9 +868,9 @@ public class S3FileSystemProvider
             throw new FileAlreadyExistsException(format("target already exists: %s", target));
         }
 
-        String bucketNameOrigin = s3Source.getFileStore().name();
+        String bucketNameOrigin = s3Source.getBucketName();
         String keySource = s3Source.getKey();
-        String bucketNameTarget = s3Target.getFileStore().name();
+        String bucketNameTarget = s3Target.getBucketName();
         String keyTarget = s3Target.getKey();
         final S3Client client = s3Source.getFileSystem().getClient();
 
@@ -954,7 +954,7 @@ public class S3FileSystemProvider
         {
             final S3Object s3Object = s3Utils.getS3Object(s3Path);
             final String key = s3Object.key();
-            final String bucket = s3Path.getFileStore().name();
+            final String bucket = s3Path.getBucketName();
             final S3AccessControlList accessControlList = new S3AccessControlList(bucket, key);
 
             accessControlList.checkAccess(modes);

--- a/src/main/java/org/carlspring/cloud/storage/s3fs/S3SeekableByteChannel.java
+++ b/src/main/java/org/carlspring/cloud/storage/s3fs/S3SeekableByteChannel.java
@@ -177,7 +177,7 @@ public class S3SeekableByteChannel
                 builder.contentType(new Tika().detect(stream, path.getFileName().toString()));
             }
 
-            builder.bucket(path.getFileStore().name());
+            builder.bucket(path.getBucketName());
             builder.key(path.getKey());
             builder.cacheControl(requestCacheControlHeader);
 

--- a/src/main/java/org/carlspring/cloud/storage/s3fs/util/S3Utils.java
+++ b/src/main/java/org/carlspring/cloud/storage/s3fs/util/S3Utils.java
@@ -59,7 +59,7 @@ public class S3Utils
     public List<S3Object> listS3Objects(S3Path s3Path)
     {
         final String key = s3Path.getKey();
-        final String bucketName = s3Path.getFileStore().name();
+        final String bucketName = s3Path.getBucketName();
         final S3Client client = s3Path.getFileSystem().getClient();
 
         // is a virtual directory
@@ -89,7 +89,7 @@ public class S3Utils
             throws NoSuchFileException
     {
         final String key = s3Path.getKey();
-        final String bucketName = s3Path.getFileStore().name();
+        final String bucketName = s3Path.getBucketName();
 
         final S3Client client = s3Path.getFileSystem().getClient();
 
@@ -177,7 +177,7 @@ public class S3Utils
         final S3Object object = getS3Object(s3Path);
 
         final String key = s3Path.getKey();
-        final String bucketName = s3Path.getFileStore().name();
+        final String bucketName = s3Path.getBucketName();
 
         final S3BasicFileAttributes attrs = toS3FileAttributes(object, key);
 

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/FilesIT.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/FilesIT.java
@@ -306,7 +306,7 @@ class FilesIT extends BaseIntegrationTest
         // upload file without paths
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[0]);
         final RequestBody requestBody = RequestBody.fromInputStream(inputStream, inputStream.available());
-        String bucketName = s3Path.getFileStore().name();
+        String bucketName = s3Path.getBucketName();
         PutObjectRequest request = PutObjectRequest.builder().bucket(bucketName).key(file1).build();
         client.putObject(request, requestBody);
 
@@ -366,7 +366,7 @@ class FilesIT extends BaseIntegrationTest
         // upload without paths
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[0]);
         final RequestBody requestBody = RequestBody.fromInputStream(inputStream, inputStream.available());
-        String bucketName = s3Path.getFileStore().name();
+        String bucketName = s3Path.getBucketName();
         PutObjectRequest request = PutObjectRequest.builder().bucket(bucketName).key(subFolder).build();
         client.putObject(request, requestBody);
 
@@ -532,7 +532,7 @@ class FilesIT extends BaseIntegrationTest
         // upload without paths
         final ByteArrayInputStream inputStream = new ByteArrayInputStream(new byte[0]);
         final RequestBody requestBody = RequestBody.fromInputStream(inputStream, inputStream.available());
-        String bucketName = s3Path.getFileStore().name();
+        String bucketName = s3Path.getBucketName();
         PutObjectRequest request = PutObjectRequest.builder().bucket(bucketName).key(fileWithFolders).build();
         client.putObject(request, requestBody);
 
@@ -555,7 +555,7 @@ class FilesIT extends BaseIntegrationTest
             Files.copy(htmlFile, result);
 
             final S3Path resultS3 = (S3Path) result;
-            final String bucketName = resultS3.getFileStore().name();
+            final String bucketName = resultS3.getBucketName();
             final String key = resultS3.getKey();
             final HeadObjectRequest request = HeadObjectRequest.builder().bucket(bucketName).key(key).build();
             final HeadObjectResponse response = resultS3.getFileSystem()
@@ -597,7 +597,7 @@ class FilesIT extends BaseIntegrationTest
             Files.copy(htmlFile, result);
 
             final S3Path resultS3 = (S3Path) result;
-            final String bucketName = resultS3.getFileStore().name();
+            final String bucketName = resultS3.getBucketName();
             final String key = resultS3.getKey();
             final HeadObjectRequest request = HeadObjectRequest.builder().bucket(bucketName).key(key).build();
             final HeadObjectResponse response = resultS3.getFileSystem()
@@ -639,7 +639,7 @@ class FilesIT extends BaseIntegrationTest
             }
 
             final S3Path resultS3 = (S3Path) result;
-            final String bucketName = resultS3.getFileStore().name();
+            final String bucketName = resultS3.getBucketName();
             final String key = resultS3.getKey();
             final HeadObjectRequest request = HeadObjectRequest.builder().bucket(bucketName).key(key).build();
             final HeadObjectResponse response = resultS3.getFileSystem()

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/S3FileSystemTest.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/S3FileSystemTest.java
@@ -228,7 +228,7 @@ class S3FileSystemTest
         {
             S3Path s3Path = (S3Path) path;
 
-            String fileStore = s3Path.getFileStore().name();
+            String fileStore = s3Path.getBucketName();
 
             Path fileName = s3Path.getFileName();
 

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/path/S3PathTest.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/path/S3PathTest.java
@@ -42,7 +42,7 @@ class S3PathTest
     {
         S3Path path = forPath("/bucket");
 
-        assertEquals("bucket", path.getFileStore().name());
+        assertEquals("bucket", path.getBucketName());
         assertEquals("", path.getKey());
     }
 
@@ -51,7 +51,7 @@ class S3PathTest
     {
         S3Path path = forPath("/bucket/");
 
-        assertEquals(path.getFileStore().name(), "bucket");
+        assertEquals(path.getBucketName(), "bucket");
         assertEquals(path.getKey(), "");
     }
 
@@ -60,7 +60,7 @@ class S3PathTest
     {
         S3Path path = forPath("/bucket/path/to/file");
 
-        assertEquals(path.getFileStore().name(), "bucket");
+        assertEquals(path.getBucketName(), "bucket");
         assertEquals(path.getKey(), "path/to/file");
     }
 
@@ -69,7 +69,7 @@ class S3PathTest
     {
         S3Path path = forPath("/bucket/path/to/dir/");
 
-        assertEquals("bucket", path.getFileStore().name());
+        assertEquals("bucket", path.getBucketName());
         assertEquals("path/to/dir/", path.getKey());
     }
 
@@ -78,7 +78,7 @@ class S3PathTest
     {
         S3Path path = forPath("/bucket/path/to/dir/");
 
-        assertEquals("bucket", path.getFileStore().name());
+        assertEquals("bucket", path.getBucketName());
         assertEquals("path/to/dir/", path.getKey());
     }
 
@@ -266,24 +266,24 @@ class S3PathTest
         S3FileSystem fileSystem = s3fsProvider.getFileSystem(S3EndpointConstant.S3_GLOBAL_URI_TEST);
         S3Path path = new S3Path(fileSystem, "/buckname");
 
-        assertEquals("buckname", path.getFileStore().name());
+        assertEquals("buckname", path.getBucketName());
         assertEquals("", path.getKey());
         assertNull(path.getParent());
         assertEquals("", path.getKey());
 
         path = new S3Path(fileSystem, "/buckname/");
 
-        assertEquals("buckname", path.getFileStore().name());
+        assertEquals("buckname", path.getBucketName());
         assertEquals("", path.getKey());
 
         path = new S3Path(fileSystem, "/buckname/file");
 
-        assertEquals("buckname", path.getFileStore().name());
+        assertEquals("buckname", path.getBucketName());
         assertEquals("file", path.getKey());
 
         path = new S3Path(fileSystem, "/buckname/dir/file");
 
-        assertEquals("buckname", path.getFileStore().name());
+        assertEquals("buckname", path.getBucketName());
         assertEquals("dir/file", path.getKey());
 
         path = new S3Path(fileSystem, "dir/file");

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/spike/FileStoreTest.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/spike/FileStoreTest.java
@@ -75,11 +75,4 @@ class FileStoreTest
         }
     }
 
-    // ~ helper methods
-
-    private Path get(String path)
-    {
-        return fs.getPath(path);
-    }
-
 }


### PR DESCRIPTION
# Pull Request Description

This pull request replaces usages of `S3Path.getFileStore().getName()` with `S3Path.getBucketName()` with the goal to have a clearer intention of what is needed. The method already exists and it is delegating to `fileStore.getName()`, so tests are still working 🎉 

# Acceptance Test

* [X] Building the code with `gradle clean build` still works.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes and my commit follows the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/)
  * [X] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [X] No

* Does this require an update of the documentation?
  * [ ] Yes, please see [provide details here]
  * [X] No
