### PR TITLE
chore(S3Path): remove and get first part of the paths with one method call

### DIFF
--- a/src/main/java/org/carlspring/cloud/storage/s3fs/S3Path.java
+++ b/src/main/java/org/carlspring/cloud/storage/s3fs/S3Path.java
@@ -81,12 +81,10 @@ public class S3Path
             Preconditions.checkArgument(!pathsURI.isEmpty(), "path must start with bucket name");
             Preconditions.checkArgument(!pathsURI.get(0).isEmpty(), "bucket name must be not empty");
 
-            String bucket = pathsURI.get(0);
+            // the filestore (bucket) is not part of the uri
+            String bucket = pathsURI.remove(0);
 
             this.fileStore = new S3FileStore(fileSystem, bucket);
-
-            // the filestore is not part of the uri
-            pathsURI.remove(0);
         }
         else
         {


### PR DESCRIPTION
# Pull Request Description

This pull request reduces the code in the `S3Path` constructor. There is a call to `get` the first item of the paths and after a call to `remove` it, but `remove` returns the item at that position, so it can be used to `get` as well.

# Acceptance Test

* [X] Building the code with `gradle clean build` still works.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes and my commit follows the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/)
  * [X] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [X] No

* Does this require an update of the documentation?
  * [ ] Yes, please see [provide details here]
  * [X] No
