### PR TITLE
Fix Command Dispatcher CI Bug

### DIFF
--- a/.github/workflows/command-dispatcher.yaml
+++ b/.github/workflows/command-dispatcher.yaml
@@ -11,7 +11,7 @@ jobs:
   slashCommandDispatch:
     runs-on: ubuntu-latest
     if: |
-      contains('["carlspring", "steve-todorov"]', github.triggering_actor) &&
+      contains(FromJSON('["carlspring", "steve-todorov"]'), github.triggering_actor) &&
       github.event.issue.pull_request
     steps:
       - name: Slash Command Dispatch


### PR DESCRIPTION
# Pull Request Description

This pull request updates the command dispatcher workflow to perform a check for an actor within an Array instead of a String. String contains a substring check so that substring usernames would pass the check.

See: https://docs.github.com/en/actions/learn-github-actions/expressions#contains

# Acceptance Test

N/A 

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes and my commit follows the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/)
  * [x] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see [provide details here]
  * [x] No
