### PR TITLE
docs: Update mkdocs and add dark mode

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -42,7 +42,16 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
-      - name: Build docks
+      - name: Get current branch name
+        id: get_branch
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request_target" ]; then
+            echo "branch_name=${{ github.event.pull_request.head.ref }}" >> $GITHUB_ENV
+          else
+            echo "branch_name=${GITHUB_REF#refs/heads/}" >> $GITHUB_ENV
+          fi
+
+      - name: Build docs
         working-directory: docs
         run: docker compose run build
 
@@ -54,8 +63,8 @@ jobs:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
         run: |
           npm install -g netlify
-          is_master=${{ github.ref_name == 'master' }}
-          is_fork=${{ github.event_name == 'pull_request_target' && github.event.pull_request.head.repo.full_name != vars.CURRENT_REPO && 'true' || 'false' }}
+          is_master=${{ env.get_branch == 'master' }}
+          is_fork=${{ github.event.pull_request.head.repo.fork == true }}
           [[ "$is_master" == "true" && "$is_fork" == "false" ]] && args=" --prod "
           netlify deploy -d site/ $args | tee build.log
           url=$(cat build.log | grep -iE  "website(.+)url" | cut -f 2- -d":" | xargs)

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ We aim to support only the latest LTS versions. At the moment this includes:
 * JDK 17
 * JDK 21
 
-Please note that although we support JDK 8 we have plans to drop it in one of our next **major** release (most likely `v2.0.0`).
+Please note that although we support JDK 8 we have plans to drop it in one of our next **major** release.
 
 ## Documentation
 

--- a/docs/content/contributing/legal/license-MIT.md
+++ b/docs/content/contributing/legal/license-MIT.md
@@ -3,6 +3,7 @@
 This is our copy of the MIT license.
 
 ## License Text
+
 ```
 --8<-- "../LICENSE.MIT.md"
 ```

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,4 +1,4 @@
-{! ../../README.md [ln:19-37] !} 
+{! ../../README.md [ln:19-47] !} 
   
 ## Installation
 
@@ -49,6 +49,7 @@
     Create/load a properties file in your project which defines the following properties:
     
     ```
+
     --8<-- "../src/test/resources/amazon-test-sample.properties"
     ``` 
     

--- a/docs/docker-compose.yml
+++ b/docs/docker-compose.yml
@@ -4,7 +4,7 @@ services:
     build:
       context: .
       dockerfile: ./docs.Dockerfile
-    image: squidfunk/mkdocs-material:5.5.9-custom
+    image: squidfunk/mkdocs-material:9.5.44-custom
     container_name: s3fs-nio-docs
     working_dir: /workspace/docs
     volumes:
@@ -15,7 +15,7 @@ services:
     build:
       context: .
       dockerfile: ./docs.Dockerfile
-    image: squidfunk/mkdocs-material:5.5.9-custom
+    image: squidfunk/mkdocs-material:9.5.44-custom
     working_dir: /workspace/docs
     command: [ "build" ]
     volumes:

--- a/docs/docs.Dockerfile
+++ b/docs/docs.Dockerfile
@@ -1,4 +1,4 @@
-FROM squidfunk/mkdocs-material:5.5.9
+FROM squidfunk/mkdocs-material:9.5.44
 
 WORKDIR /workspace/docs
 COPY requirements.txt /workspace/docs

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -8,23 +8,50 @@ docs_dir: content
 theme:
   name: material
   custom_dir: 'theme'
-  icon:
-    repo: fontawesome/brands/github-alt
+  icons:
+    repo: fontawesome/brands/github
+    fontawesome: true
 
   font:
     text: Roboto
     code: Roboto Mono
 
+  palette:
+    # Palette toggle for light mode
+    - scheme: default
+      media: "(prefers-color-scheme: light)"
+      primary: indigo
+      toggle:
+        icon: material/toggle-switch
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - scheme: slate
+      media: "(prefers-color-scheme: dark)"
+      toggle:
+        icon: material/toggle-switch-off-outline
+        name: Switch to light mode
+
   features:
-    - search.highlight
+    - announce.dismiss
+    - content.tooltips
     - meta
-    # Instant should be disabled because of a bug - not redirecting pages.
-    #- instant
+    - navigation.footer
+    #- navigation.indexes
+    - navigation.instant
+    #- navigation.sections
+    - navigation.tabs
+    - navigation.tabs.sticky
+    - navigation.top
+    - navigation.tracking
+    - search.highlight
+    - search.share
+    - search.suggest
     - tabs
 
 plugins:
   - search:
-      prebuild_index: false
+      prebuild: false
       lang:
         - en
 #  - mkdocs-pom-parser-plugin:
@@ -39,7 +66,9 @@ plugins:
 markdown_extensions:
   - admonition
   - attr_list
+  - footnotes
   - meta
+  - md_in_html
   - mdx_gh_links
   - mdx_include:
       base_path: ./content
@@ -62,8 +91,8 @@ markdown_extensions:
   - pymdownx.critic
   - pymdownx.details
   - pymdownx.emoji:
-      emoji_index: !!python/name:materialx.emoji.twemoji
-      emoji_generator: !!python/name:materialx.emoji.to_svg
+      emoji_generator: !!python/name:material.extensions.emoji.to_svg
+      emoji_index: !!python/name:material.extensions.emoji.twemoji
   - pymdownx.highlight
   - pymdownx.inlinehilite
   - pymdownx.keys
@@ -75,8 +104,10 @@ markdown_extensions:
   - pymdownx.smartsymbols
   - pymdownx.snippets:
       check_paths: true
+      restrict_base_path: False
   - pymdownx.superfences
-  - pymdownx.tabbed
+  - pymdownx.tabbed:
+      alternate_style: true
   - pymdownx.tasklist:
       custom_checkbox: true
   - pymdownx.tilde

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,14 +1,14 @@
-mkdocs==1.1.2
-mkdocs-material==5.5.11
-mdx_gh_links==0.3
-#mdx_include==1.3.3
+mkdocs~=1.6
+mkdocs-material==9.5.44
+mkdocs-material-extensions~=1.3
+mdx_gh_links==0.4
 mdx_include==1.4.2
-mkdocs-markdownextradata-plugin==0.2.1
-mkdocs-git-revision-date-plugin==0.3
-mkdocs-redirects==1.0.1
-mkdocs-htmlproofer-plugin==0.0.3
-mkdocs-pom-parser-plugin>=1.0.3
-mkdocs-minify-plugin==0.3.0
+mdx_include==1.4.2
+mkdocs-markdownextradata-plugin==0.2.5
+mkdocs-git-revision-date-plugin==0.3.2
+mkdocs-redirects==1.2.1
+mkdocs-htmlproofer-plugin==1.2.1
+mkdocs-minify-plugin==0.8.0
 # This dependency is necessary for older mkdocs versions.
 # TODO: Remove when upgrading mkdocs.
-jinja2<3.1.0
+jinja2~=3.0

--- a/docs/theme/assets/custom.css
+++ b/docs/theme/assets/custom.css
@@ -26,13 +26,11 @@
 }
 
 .md-typeset table:not([class]) td small:before {
-    content: '\a';
     white-space: pre-wrap;
 }
 
 .md-typeset table:not([class]) td small {
     font-size: 85%;
-    color: rgba(0,0,0,0.65);
 }
 
 .md-typeset .md-typeset__table {


### PR DESCRIPTION
# Pull Request Description

This pull request closes #708 .

# Acceptance Test

* [ ] Building the code with `gradle clean build` still works.

# Questions

* Does this pull request break backward compatibility? 
  * [ ] Yes and my commit follows the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/)
  * [ ] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [ ] No

* Does this require an update of the documentation?
  * [ ] Yes, please see [provide details here]
  * [ ] No


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Commented out license text in Apache 2.0 and a line in the main documentation index.
  - Updated MIT license text inclusion method.
  - Adjusted theme settings, plugin configurations, markdown extensions, social links, and navigation structure in `mkdocs.yml`.

- **Chores**
  - Upgraded image version in `docker-compose.yml` to `squidfunk/mkdocs-material:9`.
  - Updated various dependencies in `requirements.txt`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->