### PR TITLE
`S3Path.toString()` now returns the string representation of the path instead of the URI

### DIFF
--- a/src/main/java/org/carlspring/cloud/storage/s3fs/S3Path.java
+++ b/src/main/java/org/carlspring/cloud/storage/s3fs/S3Path.java
@@ -761,7 +761,9 @@ public class S3Path
     @Override
     public String toString()
     {
-        return toUri().toString();
+        final String encodedUri = normalizeURI(encode(this.uri));
+        final String toStr = normalizeURI((isAbsolute() && fileStore != null ? PATH_SEPARATOR + getBucketName() + PATH_SEPARATOR : "") + encodedUri);
+        return toStr;
     }
 
     @Override

--- a/src/main/java/org/carlspring/cloud/storage/s3fs/S3Path.java
+++ b/src/main/java/org/carlspring/cloud/storage/s3fs/S3Path.java
@@ -641,18 +641,15 @@ public class S3Path
     public URI toUri()
     {
         String encodedUri = encode(this.uri);
+        String builder = normalizeURI(encodedUri); // assuming path is relative.
 
-        // absolute
+        // when absolute path -- use full URI.
         if (this.isAbsolute())
         {
-            String builder = fileSystem.getKey() + PATH_SEPARATOR + getBucketName() + PATH_SEPARATOR + encodedUri;
+            builder = "s3://" + normalizeURI(fileSystem.getKey() + PATH_SEPARATOR + getBucketName() + PATH_SEPARATOR + encodedUri);
+        }
 
-            return URI.create("s3://" + normalizeURI(builder));
-        }
-        else
-        {
-            return URI.create(encodedUri);
-        }
+        return URI.create(builder);
     }
 
     /**

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/S3FileStoreTest.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/S3FileStoreTest.java
@@ -122,7 +122,7 @@ class S3FileStoreTest
 
         assertNull(rootDirectory.getFileName());
         assertTrue(rootDirectory.isAbsolute());
-        assertEquals("s3://access-mocked@s3.test.amazonaws.com/bucket/", rootDirectory.toAbsolutePath().toString());
+        assertEquals("/bucket/", rootDirectory.toAbsolutePath().toString());
         assertEquals("s3://access-mocked@s3.test.amazonaws.com/bucket/", rootDirectory.toUri().toString());
     }
 

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/fileSystemProvider/CreateDirectoryTest.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/fileSystemProvider/CreateDirectoryTest.java
@@ -58,7 +58,7 @@ class CreateDirectoryTest
         Path path = Files.createDirectories(resolve);
 
         // assertions
-        assertEquals("s3://s3.test.amazonaws.com/newer-bucket/folder", path.toAbsolutePath().toString());
+        assertEquals("/newer-bucket/folder", path.toAbsolutePath().toString());
         assertTrue(Files.exists(root));
         assertTrue(Files.isDirectory(root));
         assertTrue(Files.exists(resolve));

--- a/src/test/java/org/carlspring/cloud/storage/s3fs/path/S3PathTest.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/path/S3PathTest.java
@@ -6,6 +6,7 @@ import org.carlspring.cloud.storage.s3fs.S3UnitTestBase;
 import org.carlspring.cloud.storage.s3fs.util.S3EndpointConstant;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Path;
 import java.nio.file.WatchEvent;
 import java.util.HashMap;
@@ -342,6 +343,18 @@ class S3PathTest
         assertThat(first.hashCode()).isEqualTo(second.hashCode());
         assertThat(first).isNotEqualTo(third);
         assertThat(first.hashCode()).isNotEqualTo(third.hashCode());
+    }
+
+    @Test
+    void toStringTest()
+    {
+        S3Path relative = forPath("some/key/without/a/bucket");
+        assertThat(relative.toString()).isEqualTo("some/key/without/a/bucket");
+        assertThat(relative.toUri()).isEqualTo(URI.create("some/key/without/a/bucket"));
+
+        S3Path absolute = forPath("/bucket/some/key/with/a/bucket");
+        assertThat(absolute.toString()).isEqualTo("/bucket/some/key/with/a/bucket");
+        assertThat(absolute.toUri()).isEqualTo(URI.create(S3_GLOBAL_URI_TEST + "bucket/some/key/with/a/bucket"));
     }
 
 }


### PR DESCRIPTION
# Pull Request Description

This pull request closes #872 

# Acceptance Test

* [x] Building the code with `gradle clean build` still works.

# Questions

* Does this pull request break backward compatibility? 
  * [x] Yes and my commit follows the [Conventional Commits Specification](https://www.conventionalcommits.org/en/v1.0.0/)
  * [ ] No

* Does this pull request require other pull requests to be merged first? 
  * [ ] Yes, please see #...
  * [x] No

* Does this require an update of the documentation?
  * [ ] Yes, please see [provide details here]
  * [x] No
