### PR TITLE
Preserve the S3 mock base directory

### DIFF
--- a/src/test/java/org/carlspring/cloud/storage/s3fs/util/S3ClientMock.java
+++ b/src/test/java/org/carlspring/cloud/storage/s3fs/util/S3ClientMock.java
@@ -161,7 +161,7 @@ public class S3ClientMock
                                                           IOException exc)
                         throws IOException
                 {
-                    if (dir != base)
+                    if (!dir.equals(base))
                     {
                         Files.delete(dir);
                     }


### PR DESCRIPTION
Hi. We are researchers from Mahidol University, Thailand, and the State University of Ceará, Brazil, working on a research project for improving open-source projects by using the latest accepted answer from Stack Overflow that matched your code snippet. We found this recommendation for improving your code from https://stackoverflow.com/a/18454342.

Note: Our study is approved by the Institutional Review Board of Mahidol University. You can find the participant information sheet explaining this study https://drive.google.com/file/d/1ml5AqrtWQ9pnifTQyTFTcWQmwp6RuPA7/view?usp=sharing.

----

## Proposed change

Compare paths by value when cleaning the mock directory so an equivalent base Path is not deleted accidentally.

<!-- Include the Testing section only when a relevant test exists and was run. Otherwise remove this comment and the entire section below. -->
## Acceptance

- [x] This change does not break backward compatibility.
- [x] This change does not depend on another pull request.
- [x] This change does not require documentation updates.
